### PR TITLE
Fix event dispatching on slide change event

### DIFF
--- a/cipr/ui/widgets/SpringBoard.lua
+++ b/cipr/ui/widgets/SpringBoard.lua
@@ -135,12 +135,11 @@ local function gotoSlide(self, target, now)
         cancelTransition(self)
         self._currentSlide = calcSlideNum(self)
 
-        -- TODO For some reason dispatching this event throws a runtime error
-        -- self:dispatchEvent(SpringBoard.CHANGE_SLIDE_EVENT, {
-        --     name = SpringBoard.CHANGE_SLIDE_EVENT,
-        --     target = target,
-        --     position = self._currentSlide
-        -- })
+        self.view:dispatchEvent({
+            name = SpringBoard.CHANGE_SLIDE_EVENT,
+            target = target,
+            position = self._currentSlide
+        })
     end
 
     if now then
@@ -233,6 +232,5 @@ end
 function SpringBoard:addEventListener(...)
     return self.view:addEventListener(...)
 end
-
 
 return SpringBoard


### PR DESCRIPTION
Interface for dispatching an event changed in recent corona lib - updated
calling the event dispatch to match the new corona interface.

Related: https://docs.coronalabs.com/api/type/EventDispatcher/dispatchEvent.html
